### PR TITLE
Ruby2.5で使うとステータスバーのボタンが消える

### DIFF
--- a/miqhub.rb
+++ b/miqhub.rb
@@ -4,6 +4,7 @@ require_relative 'command'
 require_relative 'filter'
 require_relative 'modelviewer'
 require_relative 'world'
+require_relative 'ruby_ext'
 
 module Plugin::MiqHub
   PM = Plugin::MiqHub

--- a/ruby_ext.rb
+++ b/ruby_ext.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Enumerable#filter is available only since 2.6.0
+unless Enumerable.instance_methods.include?(:filter)
+  module Enumerable
+    alias filter select
+  end
+end

--- a/ruby_ext.rb
+++ b/ruby_ext.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 # Enumerable#filter is available only since 2.6.0
-unless Enumerable.instance_methods.include?(:filter)
+unless Enumerable.instance_methods.include? :filter
+  # Add an alias added in Ruby >= 2.6
   module Enumerable
     alias filter select
   end


### PR DESCRIPTION
`Enumerable#filter`はRuby2.6.0以降でしか使えないため、それ以前のRubyでmiqhubをインストールすると、`miqhub_list`コマンドのconditionから呼ばれている`filter_miqhub_worlds`が例外を吐きます。これによってmikutterがボタン列挙を途中で諦めるため、ステータスバーのボタンが全部消滅します。